### PR TITLE
Use regex to validate discord webhook urls instead of strpos

### DIFF
--- a/dashboard/app/webhooks/index.php
+++ b/dashboard/app/webhooks/index.php
@@ -276,7 +276,7 @@ if (isset($_POST['genwebhook']))
     }
 
     $base = sanitize($_POST['baselink']);
-    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v[6-9]+)?\/webhooks\/\d{18}\/[\w\-]{68})/i';
+    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v[6-9]{1})?\/webhooks\/\d{18}\/[\w\-]{68})/i';
 
     if (preg_match($validation_regex, $base))
     {

--- a/dashboard/app/webhooks/index.php
+++ b/dashboard/app/webhooks/index.php
@@ -276,7 +276,7 @@ if (isset($_POST['genwebhook']))
     }
 
     $base = sanitize($_POST['baselink']);
-    $validation_regex = '/(http[s]:\/\/(?:ptb\.|canary\.)?(?:discord\.|discordapp\.)?com\/api\/webhooks\/[0-9]{18}\/[a-zA-Z0-9-_]+)/i';
+    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v[6-9]+)?\/webhooks\/\d{18}\/[\w\-]{68})/i';
 
     if (preg_match($validation_regex, $base))
     {

--- a/dashboard/app/webhooks/index.php
+++ b/dashboard/app/webhooks/index.php
@@ -276,9 +276,11 @@ if (isset($_POST['genwebhook']))
     }
 
     $base = sanitize($_POST['baselink']);
-    if (strpos($base, "https://discord.com/api/webhooks/") !== false || strpos($base, "https://discord.com/api/webhooks/") !== false || strpos($base, "https://discordapp.com/api/webhooks/") !== false || strpos($base, "https://ptb.discordapp.com/api/webhooks/") !== false || strpos($base, "https://canary.discordapp.com/api/webhooks/") !== false || strpos($base, "https://canary.discord.com/api/webhooks/") !== false || strpos($base, "https://ptb.discord.com/api/webhooks/") !== false)
+    $validation_regex = '/(http[s]:\/\/(?:ptb\.|canary\.)?(?:discord\.|discordapp\.)?com\/api\/webhooks\/[0-9]{18}\/[a-zA-Z0-9-_]+)/i';
+
+    if (preg_match($validation_regex, $base))
     {
-        error("This is not meant for Discord Webhooks! This is for sending requests securely to API without API link getting leaked. Please go to app settings if you want to use Discord webhook.");
+        error("This is not meant for Discord Webhooks! This is for sending requests securely to API without API link getting leaked. Please go to app settings if you want to use a Discord Webhook.");
     }
     else
     {

--- a/dashboard/app/webhooks/index.php
+++ b/dashboard/app/webhooks/index.php
@@ -276,7 +276,7 @@ if (isset($_POST['genwebhook']))
     }
 
     $base = sanitize($_POST['baselink']);
-    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v[6-9]{1})?\/webhooks\/\d{18}\/[\w\-]{68})/i';
+    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v\d{1,2})?\/webhooks\/\d{18}\/[\w\-]{68})/i';
 
     if (preg_match($validation_regex, $base))
     {

--- a/dashboard/app/webhooks/index.php
+++ b/dashboard/app/webhooks/index.php
@@ -276,7 +276,7 @@ if (isset($_POST['genwebhook']))
     }
 
     $base = sanitize($_POST['baselink']);
-    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v\d{1,2})?\/webhooks\/\d{18}\/[\w\-]{68})/i';
+    $validation_regex = '/(https?:\/\/(?:ptb\.|canary\.)?discord(app)?\.com\/api(?:\/v\d{1,2})?\/webhooks\/\d{17,19}\/[\w\-]{68})/i';
 
     if (preg_match($validation_regex, $base))
     {


### PR DESCRIPTION
Changed discord webhook url check to use regex instead of strpos
Fixed grammar on error message if discord webhook is supplied.