### PR TITLE
Removed "contact us" via email for login and register

### DIFF
--- a/register/index.php
+++ b/register/index.php
@@ -235,7 +235,6 @@ if (isset($_SESSION['username'])) {
                 <!--begin::Links-->
                 <div class="d-flex align-items-center fw-bold fs-6">
                     <a href="https://keyauth.cc" class="text-muted text-hover-primary px-2">About</a>
-                    <a href="mailto:contact@keyauth.com" class="text-muted text-hover-primary px-2">Contact</a>
                     <a href="https://discord.gg/keyauth" class="text-muted text-hover-primary px-2">Contact Us</a>
                 </div>
                 <!--end::Links-->


### PR DESCRIPTION
Many users use discord, as far i know nobody sent an email
I removed the contact us link in login and register form